### PR TITLE
Fix RuUnaplicableRuleException name

### DIFF
--- a/src/Rules-Tests/RuRulesTest.class.st
+++ b/src/Rules-Tests/RuRulesTest.class.st
@@ -69,7 +69,7 @@ RuRulesTest >> testRulesComputationErrorRaiseError [
 		should: [ self rulesToTest first copy
 				rule: [ Error signal ];
 				totalRemediationTime ]
-		raise: RuUnaplicableRuleException
+		raise: RuUnapplicableRuleError
 ]
 
 { #category : #tests }

--- a/src/Rules/RuQueryRule.class.st
+++ b/src/Rules/RuQueryRule.class.st
@@ -40,7 +40,7 @@ RuQueryRule >> = anObject [
 RuQueryRule >> computeViolations [
 	^ [ self inputQuery runOn: self model ]
 		on: Error
-		do: [ :e | RuUnaplicableRuleException signalForRule: self model: self model cachedError: e ]
+		do: [ :e | RuUnapplicableRuleError signalForRule: self model: self model cachedError: e ]
 ]
 
 { #category : #accessing }

--- a/src/Rules/RuRule.class.st
+++ b/src/Rules/RuRule.class.st
@@ -52,7 +52,7 @@ RuRule class >> rule: aValuable label: aString explanation: aMeaningString remed
 RuRule >> computeViolations [
 	^ [ self rule value: self model ]
 		on: Error
-		do: [ :e | RuUnaplicableRuleException signalForRule: self model: self model cachedError: e ]
+		do: [ :e | RuUnapplicableRuleError signalForRule: self model: self model cachedError: e ]
 ]
 
 { #category : #accessing }

--- a/src/Rules/RuUnapplicableRuleError.class.st
+++ b/src/Rules/RuUnapplicableRuleError.class.st
@@ -22,7 +22,7 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : #RuUnaplicableRuleException,
+	#name : #RuUnapplicableRuleError,
 	#superclass : #Error,
 	#instVars : [
 		'cachedError',
@@ -33,7 +33,7 @@ Class {
 }
 
 { #category : #signaling }
-RuUnaplicableRuleException class >> signalForRule: aRule model: aCollection cachedError: anError [
+RuUnapplicableRuleError class >> signalForRule: aRule model: aCollection cachedError: anError [
 	self new
 		rule: aRule;
 		model: aCollection;
@@ -42,28 +42,28 @@ RuUnaplicableRuleException class >> signalForRule: aRule model: aCollection cach
 ]
 
 { #category : #accessing }
-RuUnaplicableRuleException >> cachedError [
+RuUnapplicableRuleError >> cachedError [
 	^ cachedError
 ]
 
 { #category : #accessing }
-RuUnaplicableRuleException >> cachedError: anObject [
+RuUnapplicableRuleError >> cachedError: anObject [
 	cachedError := anObject
 ]
 
 { #category : #accessing }
-RuUnaplicableRuleException >> messageText [
+RuUnapplicableRuleError >> messageText [
 	^ 'The computation of the rule "{1}" failed on {2}.
 Error: 
 {3}' format: {rule label . model printString . cachedError signalerContext shortStack}
 ]
 
 { #category : #accessing }
-RuUnaplicableRuleException >> model: anObject [
+RuUnapplicableRuleError >> model: anObject [
 	model := anObject
 ]
 
 { #category : #accessing }
-RuUnaplicableRuleException >> rule: anObject [
+RuUnapplicableRuleError >> rule: anObject [
 	rule := anObject
 ]


### PR DESCRIPTION
Renamed RuUnaplicableRuleException to RuUnapplicableRuleError.
'Unaplicable' -> 'UnapPlicable'
Since it inherit from error, it should be suffixed with 'Error' not 'Exception'.