### PR TITLE
fix-RuUnapplicableRuleError-name

### DIFF
--- a/src/Rules/RuUnaplicableRuleException.class.st
+++ b/src/Rules/RuUnaplicableRuleException.class.st
@@ -1,0 +1,15 @@
+"
+I am here to ensure backward-compatiblity after the renaming of my super-class.
+
+Do not use me.
+"
+Class {
+	#name : #RuUnaplicableRuleException,
+	#superclass : #RuUnapplicableRuleError,
+	#category : #'Rules-Exceptions'
+}
+
+{ #category : #deprecation }
+RuUnaplicableRuleException class >> isDeprecated [
+	^ true
+]

--- a/src/Rules/RuUnaplicableRuleException.class.st
+++ b/src/Rules/RuUnaplicableRuleException.class.st
@@ -6,7 +6,7 @@ Do not use me.
 Class {
 	#name : #RuUnaplicableRuleException,
 	#superclass : #RuUnapplicableRuleError,
-	#category : #'Rules-Exceptions'
+	#category : #'Rules-Errors'
 }
 
 { #category : #deprecation }

--- a/src/Rules/RuUnapplicableRuleError.class.st
+++ b/src/Rules/RuUnapplicableRuleError.class.st
@@ -29,7 +29,7 @@ Class {
 		'rule',
 		'model'
 	],
-	#category : #'Rules-Exceptions'
+	#category : #'Rules-Errors'
 }
 
 { #category : #signaling }


### PR DESCRIPTION
- Introduce subclass with old name for backward-compatibility.- Renamed 'Exceptions' tag as 'Errors'.