### PR TITLE
6-Rename-RuRootRule-as-RuRulesManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Note you can replace the #master by another branch such as #development or a tag
 
 ## Quick start
 
-To create a batch of rules to run on a model you first need to create a `RuRootRule`.
+To create a batch of rules to run on a model you first need to create a `RuRulesManager`.
 
 A root rule is a composite rule that will know the model which the rules should apply and that contains all the rules. It can be considered as the rules manager.
 
 ```Smalltalk
 model := #(2 4 6 8 11 14).
 
-rulesManager := RuRootRule
+rulesManager := RuRulesManager
 	labelled: 'My number collection rules'
 	explanation: 'This composite rule contains all the constraits my collection of numbers should respect.'
 	model: model.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note you can replace the #master by another branch such as #development or a tag
 
 To create a batch of rules to run on a model you first need to create a `RuRulesManager`.
 
-A root rule is a composite rule that will know the model which the rules should apply and that contains all the rules. It can be considered as the rules manager.
+A rule manager is a composite rule that will know the model which the rules should apply and that contains all the rules.
 
 ```Smalltalk
 model := #(2 4 6 8 11 14).

--- a/documentation/Documentation.md
+++ b/documentation/Documentation.md
@@ -9,7 +9,7 @@ This project provides objects to represent rulesto not violate on a model and al
 - [Design](#design)
 - [Rules](#rules)
   * [RuCompositeRule](#rucompositerule)
-  * [RuRootRule](#rurootrule)
+  * [RuRulesManager](#rurulesmanager)
   * [RuRule](#rurule)
   * [RuQueryRule](#ruqueryrule)
 
@@ -18,14 +18,14 @@ This project provides objects to represent rulesto not violate on a model and al
 
 ## Quick start
 
-To create a batch of rules to run on a model you first need to create a `RuRootRule`.
+To create a batch of rules to run on a model you first need to create a `RuRulesManager`.
 
 A root rule is a composite rule that will know the model which the rules should apply and that contains all the rules. It can be considered as the rules manager.
 
 ```Smalltalk
 model := #(2 4 6 8 11 14).
 
-rulesManager := RuRootRule
+rulesManager := RuRulesManager
 	labelled: 'My number collection rules'
 	explanation: 'This composite rule contains all the constraits my collection of numbers should respect.'
 	model: model.

--- a/documentation/Documentation.md
+++ b/documentation/Documentation.md
@@ -20,7 +20,7 @@ This project provides objects to represent rulesto not violate on a model and al
 
 To create a batch of rules to run on a model you first need to create a `RuRulesManager`.
 
-A root rule is a composite rule that will know the model which the rules should apply and that contains all the rules. It can be considered as the rules manager.
+A rule manager is a composite rule that will know the model which the rules should apply and that contains all the rules.
 
 ```Smalltalk
 model := #(2 4 6 8 11 14).

--- a/src/Rules-Tests/RuRootRuleTest.class.st
+++ b/src/Rules-Tests/RuRootRuleTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #helpers }
 RuRootRuleTest >> actualClass [
-	^ RuRootRule
+	^ RuRulesManager
 ]
 
 { #category : #helpers }

--- a/src/Rules-Tests/RuRulesManagerTest.class.st
+++ b/src/Rules-Tests/RuRulesManagerTest.class.st
@@ -1,26 +1,26 @@
 "
-A RuRootRuleTest is a test class for testing the behavior of RuRootRule
+A RuRulesManagerTest is a test class for testing the behavior of RuRulesManager
 "
 Class {
-	#name : #RuRootRuleTest,
+	#name : #RuRulesManagerTest,
 	#superclass : #RuCompositeRuleTest,
 	#category : #'Rules-Tests'
 }
 
 { #category : #helpers }
-RuRootRuleTest >> actualClass [
+RuRulesManagerTest >> actualClass [
 	^ RuRulesManager
 ]
 
 { #category : #helpers }
-RuRootRuleTest >> newInstance [
+RuRulesManagerTest >> newInstance [
 	^ super newInstance
 		model: self mockModel;
 		yourself
 ]
 
 { #category : #running }
-RuRootRuleTest >> setUp [
+RuRulesManagerTest >> setUp [
 	super setUp.
 	rootRule := rule
 ]

--- a/src/Rules-Tests/RuTestCase.class.st
+++ b/src/Rules-Tests/RuTestCase.class.st
@@ -88,5 +88,5 @@ RuTestCase >> query: aLabelString meaning: aMeaningString as: aBlock remediation
 
 { #category : #helpers }
 RuTestCase >> rootRule [
-	^ RuRootRule labelled: 'Root rule' explanation: 'Test' model: self mockModel
+	^ RuRulesManager labelled: 'Root rule' explanation: 'Test' model: self mockModel
 ]

--- a/src/Rules/RuRootRule.class.st
+++ b/src/Rules/RuRootRule.class.st
@@ -1,69 +1,15 @@
 "
-Description
--------------------
+I am here to ensure backward-compatiblity after the renaming of my super-class.
 
-I am a simple composite rule just holding a model. I should be the root the user can use and all my subrules will use my model to compute their remediation time.
-
-Example
--------------------
-
-	RuRootRule on: aModel	
- 
-Internal Representation and Key Implementation Points.
---------------------
-
-    Instance Variables
-	model:					<aModel>			The model on which look for violations.
-	workingHours:		<anNumber>		The number of working hours to use to deduce technical debt.
-
+Do not use me.
 "
 Class {
 	#name : #RuRootRule,
-	#superclass : #RuCompositeRule,
-	#instVars : [
-		'model',
-		'workingHours'
-	],
+	#superclass : #RuRulesManager,
 	#category : #'Rules-Model'
 }
 
-{ #category : #'instance creation' }
-RuRootRule class >> labelled: aString explanation: anotherString model: aModel [
-	^ (super labelled: aString explanation: anotherString)
-		model: aModel;
-		yourself
-]
-
-{ #category : #initialization }
-RuRootRule >> initialize [
-	super initialize.
-	workingHours := 8
-]
-
-{ #category : #convenience }
-RuRootRule >> listAllRules [
-	^ self allChildren
-]
-
-{ #category : #accessing }
-RuRootRule >> model [
-	^ model
-]
-
-{ #category : #accessing }
-RuRootRule >> model: aModel [
-	self model = aModel ifTrue: [ ^ self ].
-
-	model := aModel.
-	self resetCache
-]
-
-{ #category : #accessing }
-RuRootRule >> workingHours [
-	^ workingHours
-]
-
-{ #category : #accessing }
-RuRootRule >> workingHours: anObject [
-	workingHours := anObject
+{ #category : #deprecation }
+RuRootRule class >> isDeprecated [
+	^ true
 ]

--- a/src/Rules/RuRule.class.st
+++ b/src/Rules/RuRule.class.st
@@ -13,7 +13,7 @@ Example
 ------------------
 	""Example on a model from Moose""
 
-	(RuRootRule on: MooseModel new)
+	(RuRulesManager on: MooseModel new)
 		addRule:
 			(RuRule
 				ruleBlock: [ :aModel | aModel allClasses select: [ :e | e numberOfLinesOfCode > 100 ] ]

--- a/src/Rules/RuRulesManager.class.st
+++ b/src/Rules/RuRulesManager.class.st
@@ -1,0 +1,69 @@
+"
+Description
+-------------------
+
+I am a simple composite rule just holding a model. I should be the root the user can use and all my subrules will use my model to compute their remediation time.
+
+Example
+-------------------
+
+	RuRootRule on: aModel	
+ 
+Internal Representation and Key Implementation Points.
+--------------------
+
+    Instance Variables
+	model:					<aModel>			The model on which look for violations.
+	workingHours:		<anNumber>		The number of working hours to use to deduce technical debt.
+
+"
+Class {
+	#name : #RuRulesManager,
+	#superclass : #RuCompositeRule,
+	#instVars : [
+		'model',
+		'workingHours'
+	],
+	#category : #'Rules-Model'
+}
+
+{ #category : #'instance creation' }
+RuRulesManager class >> labelled: aString explanation: anotherString model: aModel [
+	^ (super labelled: aString explanation: anotherString)
+		model: aModel;
+		yourself
+]
+
+{ #category : #initialization }
+RuRulesManager >> initialize [
+	super initialize.
+	workingHours := 8
+]
+
+{ #category : #convenience }
+RuRulesManager >> listAllRules [
+	^ self allChildren
+]
+
+{ #category : #accessing }
+RuRulesManager >> model [
+	^ model
+]
+
+{ #category : #accessing }
+RuRulesManager >> model: aModel [
+	self model = aModel ifTrue: [ ^ self ].
+
+	model := aModel.
+	self resetCache
+]
+
+{ #category : #accessing }
+RuRulesManager >> workingHours [
+	^ workingHours
+]
+
+{ #category : #accessing }
+RuRulesManager >> workingHours: anObject [
+	workingHours := anObject
+]

--- a/src/Rules/RuRulesManager.class.st
+++ b/src/Rules/RuRulesManager.class.st
@@ -7,7 +7,7 @@ I am a simple composite rule just holding a model. I should be the root the user
 Example
 -------------------
 
-	RuRootRule on: aModel	
+	RuRulesManager on: aModel	
  
 Internal Representation and Key Implementation Points.
 --------------------


### PR DESCRIPTION
Fixes #6 

Renamed RuRootRule  as RuRulesManager.
Renamed test class accordingly.
Fixed occurences in comments.